### PR TITLE
Re-raise exception after sending notification

### DIFF
--- a/knockknock/email_sender.py
+++ b/knockknock/email_sender.py
@@ -60,6 +60,7 @@ def email_sender(recipient_email: str, sender_email: str = None):
                             "Traceback",
                             '%s' % traceback.format_exc()]
                 yag_sender.send(recipient_email, 'Training has crashed ☠️', contents)
+                raise ex
 
         return wrapper_sender
 

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -76,6 +76,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                 dump['text'] = '\n'.join(contents)
                 dump['icon_emoji'] = ':skull_and_crossbones:'
                 requests.post(webhook_url, json.dumps(dump))
+                raise ex
 
         return wrapper_sender
 


### PR DESCRIPTION
Hello! Love the decorators! ✨ 

This makes the exception be re-raised after being caught.

Exceptions might be used for flow control, or there might be other steps relying on a valid state. In both these situations it would be better to not swallow the exception.

```python
@email_sender(recipient_email="<your_email@address.com>")
def train_your_nicest_model(your_nicest_parameters):
    import time
    time.sleep(10000)
    if model == some_bad_condition:
        raise TotallyValidException("oh no")

if __name__ == "__main__":
    try:
        train_your_nicest_model(some_nice_parameters)
    except TotallyValidException:
        print("i expected that")
```

```python
@email_sender(recipient_email="<your_email@address.com>")
def train_your_nicest_model(your_nicest_parameters):
    import time
    time.sleep(10000)
    raise SomethingWentWrong("oh no")

if __name__ == "__main__":
    train_your_nicest_model(some_nice_parameters)
    do_something_that_relys_on_successful_completion()
```