### PR TITLE
Be notified when running applications from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ There are currently three ways to setup notifications: email, Slack and Telegram
 
 The service relies on [Yagmail](https://github.com/kootenpv/yagmail) a GMAIL/SMTP client. You'll need a gmail email address to use it (you can setup one [here](https://accounts.google.com), it's free). I recommend creating a new one (rather than your usual one) since you'll have to modify the account's security settings to allow the Python library to access it by [Turning on less secure apps](https://devanswers.co/allow-less-secure-apps-access-gmail-account/).
 
+
+#### Python
+
 ```python
 from knockknock import email_sender
 
@@ -34,6 +37,15 @@ def train_your_nicest_model(your_nicest_parameters):
     time.sleep(10000)
 ```
 
+#### Command-line
+
+```bash
+knockknock email \
+    --recipient-email <your_email@address.com> \
+    --sender-email <grandma's_email@gmail.com> \
+    sleep 10
+```
+
 If `sender_email` is not specified, then `recipient_email` will be also used for sending.
 
 Note that launching this will asks you for the sender's email password. It will be safely stored in the system keyring service through the [`keyring` Python library](https://pypi.org/project/keyring/).
@@ -41,6 +53,8 @@ Note that launching this will asks you for the sender's email password. It will 
 ### Slack
 
 Similarly, you can also use Slack to get notifications. You'll have to get your Slack room [weebhook URL](https://api.slack.com/incoming-webhooks#create_a_webhook) and optionally your [user id](https://api.slack.com/methods/users.identity) (if you want to tag yourself or someone else).
+
+#### Python
 
 ```python
 from knockknock import slack_sender
@@ -54,11 +68,24 @@ def train_your_nicest_model(your_nicest_parameters):
 
 You can also specify an optional argument to tag specific people: `user_mentions=[<your_slack_id>, <grandma's_slack_id>]`.
 
+#### Command-line
+
+```bash
+knockknock slack \
+    --webhook-url <webhook_url_to_your_slack_room> \
+    --channel <your_favorite_slack_channel> \
+    sleep 10
+```
+
+You can also specify an optional argument to tag specific people: `--user-mentions <your_slack_id>,<grandma's_slack_id>`.
+
 ### Telegram
 
 You can also use Telegram Messenger to get notifications. You'll first have to create your own notification bot by following the three steps provided by Telegram [here](https://core.telegram.org/bots#6-botfather) and save your API access `TOKEN`.
 
 Telegram bots are shy and can't send the first message so you'll have to do the first step. By sending the first message, you'll be able to get the `chat_id` required (identification of your messaging room) by visiting `https://api.telegram.org/bot<YourBOTToken>/getUpdates` and get the `int` under the key `message['chat']['id']`.
+
+#### Python
 
 ```python
 from knockknock import telegram_sender
@@ -68,4 +95,13 @@ CHAT_ID: int = <your_messaging_room_id>
 def train_your_nicest_model(your_nicest_parameters):
     import time
     time.sleep(10000)
+```
+
+#### Command-line
+
+```bash
+knockknock telegram \
+    --token <your_api_token> \
+    --chat-id <your_messaging_room_id> \
+    sleep 10
 ```

--- a/knockknock/__main__.py
+++ b/knockknock/__main__.py
@@ -1,0 +1,68 @@
+import argparse
+import subprocess
+
+from knockknock import email_sender, slack_sender, telegram_sender
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="KnockKnock - Be notified when your training is complete.")
+    parser.add_argument("--verbose", required=False, action="store_true",
+                        help="Show full command in notification.")
+    subparsers = parser.add_subparsers()
+
+    email_parser = subparsers.add_parser(
+        name="email", description="Send a Slack message before and after function " +
+        "execution, with start and end status (sucessfully or crashed).")
+    email_parser.add_argument(
+        "--recipient-email", type=str, required=True,
+        help="The email address to notify.")
+    email_parser.add_argument(
+        "--sender-email", type=str, required=False,
+        help="The email adress to send the messages." +
+        "(default: use the same address as recipient-email)")
+    email_parser.set_defaults(sender_func=email_sender)
+
+    slack_parser = subparsers.add_parser(
+        name="slack", description="Send a Slack message before and after function " +
+        "execution, with start and end status (sucessfully or crashed).")
+    slack_parser.add_argument(
+        "--webhook-url", type=str, required=True,
+        help="The webhook URL to access your slack room.")
+    slack_parser.add_argument(
+        "--channel", type=str, required=True, help="The slack room to log.")
+    slack_parser.add_argument(
+        "--user-mentions", type=lambda s: s.split(","), required=False,
+        help="Optional user ids to notify, as comma seperated list.")
+    slack_parser.set_defaults(sender_func=slack_sender)
+
+    telegram_parser = subparsers.add_parser(
+        name="telegram", description="Send a Telegram message before and after " +
+        "function execution, with start and end status (sucessfully or crashed).")
+    telegram_parser.add_argument(
+        "--token", type=str, required=True,
+        help="The API access TOKEN required to use the Telegram API.")
+    telegram_parser.add_argument(
+        "--chat-id", type=int, required=True,
+        help="Your chat room id with your notification BOT.")
+    telegram_parser.set_defaults(sender_func=telegram_sender)
+
+    args, remaining_args = parser.parse_known_args()
+    args = vars(args)
+
+    sender_func = args.pop("sender_func", None)
+
+    if sender_func is None:
+        parser.print_help()
+        exit(1)
+
+    verbose = args.pop("verbose")
+    def run_func(): return subprocess.run(remaining_args, check=True)
+    run_func.__name__ = " ".join(
+        remaining_args) if verbose else remaining_args[0]
+
+    sender_func(**args)(run_func)()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,29 +2,34 @@ from setuptools import setup, find_packages
 from io import open
 
 setup(
-	name='knockknock',
-	version='0.1.1',
-	description='Be notified when your training is complete with only two additional lines of code',
-	long_description=open('README.md', 'r', encoding='utf-8').read(),
-	long_description_content_type='text/markdown',
-	url='http://github.com/huggingface/knockknock',
-	author='Victor SANH',
-	author_email='victorsanh@gmail.com',
-	license='MIT',
-	packages=find_packages(),
-	zip_safe=False,
-	python_requires='>=3.6',
-	install_requires=[
-		'yagmail>=0.11.214',
-		'keyring',
-		'python-telegram-bot',
-		'requests'
-	],
-	classifiers=[
-          'Intended Audience :: Science/Research',
-          'Development Status :: 3 - Alpha',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3.6',
-          'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    name='knockknock',
+    version='0.1.1',
+    description='Be notified when your training is complete with only two additional lines of code',
+    long_description=open('README.md', 'r', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
+    url='http://github.com/huggingface/knockknock',
+    author='Victor SANH',
+    author_email='victorsanh@gmail.com',
+    license='MIT',
+    packages=find_packages(),
+        entry_points={
+            'console_scripts': [
+                'knockknock = knockknock.__main__:main'
+            ]
+    },
+    zip_safe=False,
+    python_requires='>=3.6',
+    install_requires=[
+        'yagmail>=0.11.214',
+        'keyring',
+        'python-telegram-bot',
+        'requests'
+    ],
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ]
 )


### PR DESCRIPTION
I often run training via a command-line interface (e.g. AllenNLP), therefore I extended the decorators to directly wrap a command-line application.
For example, wrapping a command and be notified via Telegram:
```bash
knockknock telegram \
    --token <your_api_token> \
    --chat-id <your_messaging_room_id> \
    sleep 10
```