### PR TITLE
Added support for multiple recipient emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ def train_your_nicest_model(your_nicest_parameters):
 
 ```bash
 knockknock email \
-    --recipient-emails [<your_email@address.com>, <your_second_email@address.com>] \
+    --recipient-emails <your_email@address.com>,<your_second_email@address.com> \
     --sender-email <grandma's_email@gmail.com> \
     sleep 10
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The service relies on [Yagmail](https://github.com/kootenpv/yagmail) a GMAIL/SMT
 ```python
 from knockknock import email_sender
 
-@email_sender(recipient_email_list=["<your_email@address.com>", "<your_second_email@address.com>"], sender_email="<grandma's_email@gmail.com>")
+@email_sender(recipient_emails=["<your_email@address.com>", "<your_second_email@address.com>"], sender_email="<grandma's_email@gmail.com>")
 def train_your_nicest_model(your_nicest_parameters):
     import time
     time.sleep(10000)
@@ -41,7 +41,7 @@ def train_your_nicest_model(your_nicest_parameters):
 
 ```bash
 knockknock email \
-    --recipient-email-list [<your_email@address.com>, <your_second_email@address.com>] \
+    --recipient-emails [<your_email@address.com>, <your_second_email@address.com>] \
     --sender-email <grandma's_email@gmail.com> \
     sleep 10
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The service relies on [Yagmail](https://github.com/kootenpv/yagmail) a GMAIL/SMT
 ```python
 from knockknock import email_sender
 
-@email_sender(recipient_email="<your_email@address.com>", sender_email="<grandma's_email@gmail.com>")
+@email_sender(recipient_email_list=["<your_email@address.com>", "<your_second_email@address.com>"], sender_email="<grandma's_email@gmail.com>")
 def train_your_nicest_model(your_nicest_parameters):
     import time
     time.sleep(10000)
@@ -41,7 +41,7 @@ def train_your_nicest_model(your_nicest_parameters):
 
 ```bash
 knockknock email \
-    --recipient-email <your_email@address.com> \
+    --recipient-email-list [<your_email@address.com>, <your_second_email@address.com>] \
     --sender-email <grandma's_email@gmail.com> \
     sleep 10
 ```

--- a/knockknock/__main__.py
+++ b/knockknock/__main__.py
@@ -15,12 +15,12 @@ def main():
         name="email", description="Send an email before and after function " +
         "execution, with start and end status (sucessfully or crashed).")
     email_parser.add_argument(
-        "--recipient-email", type=str, required=True,
-        help="The email address to notify.")
+        "--recipient-email-list", type=list, required=True,
+        help="The email addresses to notify.")
     email_parser.add_argument(
         "--sender-email", type=str, required=False,
         help="The email adress to send the messages." +
-        "(default: use the same address as recipient-email)")
+        "(default: use the same address as the first email in `recipient-email-list`)")
     email_parser.set_defaults(sender_func=email_sender)
 
     slack_parser = subparsers.add_parser(

--- a/knockknock/__main__.py
+++ b/knockknock/__main__.py
@@ -15,8 +15,8 @@ def main():
         name="email", description="Send an email before and after function " +
         "execution, with start and end status (sucessfully or crashed).")
     email_parser.add_argument(
-        "--recipient-emails", type=list, required=True,
-        help="The email addresses to notify.")
+        "--recipient-emails", type=lambda s: s.split(","), required=True,
+        help="The email addresses to notify. as comma separated list.")
     email_parser.add_argument(
         "--sender-email", type=str, required=False,
         help="The email adress to send the messages." +

--- a/knockknock/__main__.py
+++ b/knockknock/__main__.py
@@ -15,12 +15,12 @@ def main():
         name="email", description="Send an email before and after function " +
         "execution, with start and end status (sucessfully or crashed).")
     email_parser.add_argument(
-        "--recipient-email-list", type=list, required=True,
+        "--recipient-emails", type=list, required=True,
         help="The email addresses to notify.")
     email_parser.add_argument(
         "--sender-email", type=str, required=False,
         help="The email adress to send the messages." +
-        "(default: use the same address as the first email in `recipient-email-list`)")
+        "(default: use the same address as the first email in `recipient-emails`)")
     email_parser.set_defaults(sender_func=email_sender)
 
     slack_parser = subparsers.add_parser(

--- a/knockknock/__main__.py
+++ b/knockknock/__main__.py
@@ -16,7 +16,7 @@ def main():
         "execution, with start and end status (sucessfully or crashed).")
     email_parser.add_argument(
         "--recipient-emails", type=lambda s: s.split(","), required=True,
-        help="The email addresses to notify. as comma separated list.")
+        help="The email addresses to notify, as comma separated list.")
     email_parser.add_argument(
         "--sender-email", type=str, required=False,
         help="The email adress to send the messages." +

--- a/knockknock/email_sender.py
+++ b/knockknock/email_sender.py
@@ -7,21 +7,21 @@ import yagmail
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-def email_sender(recipient_email_list: list, sender_email: str = None):
+def email_sender(recipient_emails: list, sender_email: str = None):
     """
     Email sender wrapper: execute func, send an email with the end status
     (sucessfully finished or crashed) at the end. Also send an email before
     executing func.
 
-    `recipient_email_list`: list
+    `recipient_emails`: list[str]
         A list of email addresses to notify.
     `sender_email`: str (default=None)
         The email adress to send the messages. If None, use the same
-        address as the first recipient email in `recipient_email_list`
-        if length of `recipient_email_list` is more than 0.
+        address as the first recipient email in `recipient_emails`
+        if length of `recipient_emails` is more than 0.
     """
-    if sender_email is None and len(recipient_email_list) > 0:
-        sender_email = recipient_email_list[0]
+    if sender_email is None and len(recipient_emails) > 0:
+        sender_email = recipient_emails[0]
     yag_sender = yagmail.SMTP(sender_email)
 
     def decorator_sender(func):
@@ -48,8 +48,8 @@ def email_sender(recipient_email_list: list, sender_email: str = None):
                             'Machine name: %s' % host_name,
                             'Main call: %s' % func_name,
                             'Starting date: %s' % start_time.strftime(DATE_FORMAT)]
-                for i in range(len(recipient_email_list)):
-                    current_recipient = recipient_email_list[i]
+                for i in range(len(recipient_emails)):
+                    current_recipient = recipient_emails[i]
                     yag_sender.send(current_recipient, 'Training has started 🎬', contents)
             try:
                 value = func(*args, **kwargs)
@@ -70,8 +70,8 @@ def email_sender(recipient_email_list: list, sender_email: str = None):
                     except:
                         contents.append('Main call returned value: %s'% "ERROR - Couldn't str the returned value.")
 
-                    for i in range(len(recipient_email_list)):
-                        current_recipient = recipient_email_list[i]
+                    for i in range(len(recipient_emails)):
+                        current_recipient = recipient_emails[i]
                         yag_sender.send(current_recipient, 'Training has sucessfully finished 🎉', contents)
 
                 return value
@@ -89,8 +89,8 @@ def email_sender(recipient_email_list: list, sender_email: str = None):
                             '%s\n\n' % ex,
                             "Traceback:",
                             '%s' % traceback.format_exc()]
-                for i in range(len(recipient_email_list)):
-                    current_recipient = recipient_email_list[i]
+                for i in range(len(recipient_emails)):
+                    current_recipient = recipient_emails[i]
                     yag_sender.send(current_recipient, 'Training has crashed ☠️', contents)
                 raise ex
 


### PR DESCRIPTION
Hey there!

I was reading through the issues page and saw a feature request to send emails to multiple recipients. I tweaked the original function into one where the user provides a list of emails instead.

It works something like this:
```python
@email_sender(recipient_email_list=["<your_email@address.com>", "<your_second_email@address.com>"], sender_email="<grandma's_email@gmail.com>")
def train_your_nicest_model(your_nicest_parameters):
    import time
    time.sleep(10000)
    return {'loss': 0.9} # Optional return value
```

It was a simple fix: I looped through all the recipient emails and sent it to all of them one by one.

In the case that the `sender_email` is `None`, it will take the first email from the `recipient_email_list` list and assign it to the `sender_email`.

Hope this is useful!