### PR TITLE
Update slack notification formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note that launching this will asks you for the sender's email password. It will 
 
 ### Slack
 
-Similarly, you can also use Slack to get notifications. You'll have to get your Slack room [webhook URL](https://api.slack.com/incoming-webhooks#create_a_webhook) and optionally your [user id](https://api.slack.com/methods/users.identity) (if you want to tag yourself or someone else).
+Similarly, you can also use Slack to get notifications. You'll have to get your Slack room [webhook URL](https://api.slack.com/incoming-webhooks#create_a_webhook) and optionally your username (if you want to tag yourself or someone else).
 
 #### Python
 
@@ -77,7 +77,7 @@ def train_your_nicest_model(your_nicest_parameters):
     return {'loss': 0.9} # Optional return value
 ```
 
-You can also specify an optional argument to tag specific people: `user_mentions=[<your_slack_id>, <grandma's_slack_id>]`.
+You can also specify an optional argument to tag specific people: `user_mentions=[<your_slack_username>, <grandma's_slack_username>]`.
 
 #### Command-line
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note that launching this will asks you for the sender's email password. It will 
 
 ### Slack
 
-Similarly, you can also use Slack to get notifications. You'll have to get your Slack room [webhook URL](https://api.slack.com/incoming-webhooks#create_a_webhook) and optionally your username (if you want to tag yourself or someone else).
+Similarly, you can also use Slack to get notifications. You'll have to get your Slack room [webhook URL](https://api.slack.com/incoming-webhooks#create_a_webhook) and optionally your [user id](https://api.slack.com/methods/users.identity) (if you want to tag yourself or someone else).
 
 #### Python
 
@@ -77,7 +77,7 @@ def train_your_nicest_model(your_nicest_parameters):
     return {'loss': 0.9} # Optional return value
 ```
 
-You can also specify an optional argument to tag specific people: `user_mentions=[<your_slack_username>, <grandma's_slack_username>]`.
+You can also specify an optional argument to tag specific people: `user_mentions=[<your_slack_id>, <grandma's_slack_id>]`.
 
 #### Command-line
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Similarly, you can also use Slack to get notifications. You'll have to get your 
 from knockknock import slack_sender
 
 webhook_url = "<webhook_url_to_your_slack_room>"
-@slack_sender(webhook_url=webhook_url, channel="<your_favorite_slack_channel>")
+@slack_sender(webhook_url=webhook_url)
 def train_your_nicest_model(your_nicest_parameters):
     import time
     time.sleep(10000)

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -59,23 +59,30 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                 if user_mentions:
                     notification = _add_mentions(notification)
 
-                dump['blocks'] =[{"type": "section",
-                                  "text": {"type": "mrkdwn", "text": notification}},
-                                 {"type": "divider"},
-                                 {
-                                     "type": "context",
-                                     "elements": [
-                                         {
-                                             "type": "mrkdwn",
-                                             "text":
-                                                 '*Machine name:* {}\n'
-                                                 '*Main call:* {}\n'
-                                                 '*Starting date:* {}\n'.format(host_name, func_name, start_time.strftime(DATE_FORMAT))
-                                         },
-                                     ],
-                                 }]
-                dump['text'] = notification
-                dump['icon_emoji'] = ':clapper:'
+                dump["blocks"] = [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": notification},
+                    },
+                    {"type": "divider"},
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Machine name:* {}\n"
+                                "*Main call:* {}\n"
+                                "*Starting date:* {}\n".format(
+                                    host_name,
+                                    func_name,
+                                    start_time.strftime(DATE_FORMAT),
+                                ),
+                            }
+                        ],
+                    },
+                ]
+                dump["text"] = notification
+                dump["icon_emoji"] = ":clapper:"
 
                 requests.post(webhook_url, json.dumps(dump))
 
@@ -91,39 +98,61 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                     elapsed_time = end_time - start_time
                     hours, remainder = divmod(elapsed_time.seconds, 3600)
                     minutes, seconds = divmod(remainder, 60)
-                    training_time = "{:2d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+                    training_time = "{:2d}:{:02d}:{:02d}".format(
+                        hours, minutes, seconds
+                    )
 
-                    dump['blocks'] = [{"type": "section",
-                                       "text": {"type": "mrkdwn", "text": notification}},
-                                      {"type": "divider"},
-                                      {
-                                          "type": "context",
-                                          "elements": [
-                                              {
-                                                  "type": "mrkdwn",
-                                                  "text":
-                                                      '*Machine name:* {}\n'
-                                                      '*Main call:* {}\n'
-                                                      '*Starting date:* {}\n'
-                                                      '*End date:* {}\n'
-                                                      '*Training Duration:* {}'.format(host_name, func_name,
-                                                                                     start_time.strftime(DATE_FORMAT), end_time.strftime(DATE_FORMAT), training_time)
-                                              },
-                                          ],
-                                      }]
+                    dump["blocks"] = [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": notification},
+                        },
+                        {"type": "divider"},
+                        {
+                            "type": "context",
+                            "elements": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": "*Machine name:* {}\n"
+                                    "*Main call:* {}\n"
+                                    "*Starting date:* {}\n"
+                                    "*End date:* {}\n"
+                                    "*Training Duration:* {}".format(
+                                        host_name,
+                                        func_name,
+                                        start_time.strftime(DATE_FORMAT),
+                                        end_time.strftime(DATE_FORMAT),
+                                        training_time,
+                                    ),
+                                }
+                            ],
+                        },
+                    ]
 
                     if value is not None:
                         dump["blocks"].append({"type": "divider"})
                         try:
                             str_value = str(value)
-                            dump["blocks"].append({"type": "section",
-                                                   "text": {"type": "mrkdwn",
-                                                            "text": '*Main call returned value:* {}'.format(str_value)}})
+                            dump["blocks"].append(
+                                {
+                                    "type": "section",
+                                    "text": {
+                                        "type": "mrkdwn",
+                                        "text": "*Main call returned value:* {}".format(
+                                            str_value
+                                        ),
+                                    },
+                                }
+                            )
                         except Exception as e:
-                            dump["blocks"].append("Couldn't str the returned value due to the following error: \n`{}`".format(e))
+                            dump["blocks"].append(
+                                "Couldn't str the returned value due to the following error: \n`{}`".format(
+                                    e
+                                )
+                            )
 
-                    dump['text'] = notification
-                    dump['icon_emoji'] = ':tada:'
+                    dump["text"] = notification
+                    dump["icon_emoji"] = ":tada:"
                     requests.post(webhook_url, json.dumps(dump))
 
                 return value
@@ -139,45 +168,49 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                 if user_mentions:
                     notification = _add_mentions(notification)
 
-                dump['blocks'] = [{"type": "section",
-                                   "text": {"type": "mrkdwn", "text": notification}},
-                                  {"type": "divider"},
-                                  {
-                                      "type": "context",
-                                      "elements": [
-                                          {
-                                              "type": "mrkdwn",
-                                              "text":
-                                                  '*Machine name:* {}\n'
-                                                  '*Main call:* {}\n'
-                                                  '*Starting date:* {}\n'
-                                                  '*Crash date:* {}\n'
-                                                  '*Time elapsed before crash:* {}'.format(host_name, func_name,
-                                                                                   start_time.strftime(DATE_FORMAT),
-                                                                                   end_time.strftime(DATE_FORMAT),
-                                                                                   training_time)
-                                          },
-                                      ],
-                                  },            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Error:* `{}`".format(ex),
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*Traceback:*\n```{}```".format(
-                        traceback.format_exc()
-                    ),
-                },
-            },]
+                dump["blocks"] = [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": notification},
+                    },
+                    {"type": "divider"},
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Machine name:* {}\n"
+                                "*Main call:* {}\n"
+                                "*Starting date:* {}\n"
+                                "*Crash date:* {}\n"
+                                "*Time elapsed before crash:* {}".format(
+                                    host_name,
+                                    func_name,
+                                    start_time.strftime(DATE_FORMAT),
+                                    end_time.strftime(DATE_FORMAT),
+                                    training_time,
+                                ),
+                            }
+                        ],
+                    },
+                    {"type": "divider"},
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "*Error:* `{}`".format(ex)},
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Traceback:*\n```{}```".format(
+                                traceback.format_exc()
+                            ),
+                        },
+                    },
+                ]
 
-                dump['text'] = notification
-                dump['icon_emoji'] = ':skull_and_crossbones:'
+                dump["text"] = notification
+                dump["icon_emoji"] = ":skull_and_crossbones:"
                 requests.post(webhook_url, json.dumps(dump))
                 raise ex
 

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -111,7 +111,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                         {
                             "type": "mrkdwn",
                             "text": "*Machine name:* {}\n"
-                            "*Main call:* {}\n"
+                            "*Main call:* `{}`\n"
                             "*Starting date:* {}\n"
                             "*Crash date:* {}\n"
                             "*Time elapsed before crash:* {}".format(
@@ -171,7 +171,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                         {
                             "type": "mrkdwn",
                             "text": "*Machine name:* {}\n"
-                            "*Main call:* {}\n"
+                            "*Main call:* `{}`\n"
                             "*Starting date:* {}\n"
                             "*End date:* {}\n"
                             "*Training Duration:* {}".format(
@@ -195,7 +195,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": "*Main call returned value:* {}".format(
+                                "text": "*Main call returned value:* `{}`".format(
                                     str_value
                                 ),
                             },
@@ -211,15 +211,19 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
             return blocks
 
         def _format_train_time(end_time, start_time):
-            """Returns a time delta in format HH:MM:SS"""
+            """Returns a time delta as a string in the format '%d %H:%M:%S'"""
             elapsed_time = end_time - start_time
-            hours, remainder = divmod(elapsed_time.seconds, 3600)
+            days, remainder = divmod(elapsed_time.seconds, 86400)
+            hours, remainder = divmod(remainder, 24)
             minutes, seconds = divmod(remainder, 60)
             training_time = "{:2d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+
+            if days:
+                training_time = "{}d ".format(days) + training_time
             return training_time
 
         def _add_mentions(notification):
-            notification = " ".join(user_mentions) + " " + notification
+            notification = notification + " " + " ".join(user_mentions)
             return notification
 
         return wrapper_sender

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -22,7 +22,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
     `channel`: str
         The slack room to log.
     `user_mentions`: List[str] (default=[])
-        Optional usernames to notify.
+        Optional user ids to notify.
         Visit https://api.slack.com/methods/users.identity for more details.
     """
 
@@ -33,7 +33,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
     }
 
     if user_mentions:
-        user_mentions = ["@{}".format(user) for user in user_mentions if not user.startswith("@")]
+        user_mentions = ["<@{}>".format(user) for user in user_mentions]
 
     def decorator_sender(func):
         @functools.wraps(func)
@@ -149,7 +149,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                         {
                             "type": "mrkdwn",
                             "text": "*Machine name:* {}\n"
-                            "*Main call:* {}\n"
+                            "*Main call:* `{}`\n"
                             "*Starting date:* {}\n".format(
                                 host_name, func_name, start_time.strftime(DATE_FORMAT)
                             ),
@@ -190,7 +190,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                 blocks.append({"type": "divider"})
                 try:
                     str_value = str(value)
-                    dump["blocks"].append(
+                    blocks.append(
                         {
                             "type": "section",
                             "text": {

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -99,6 +99,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                 raise ex
 
         def _error_message(ex, func_name, host_name, notification, start_time):
+            """Uses Slack blocks to create a formatted report of exception 'ex'."""
             end_time = datetime.datetime.now()
             training_time = _format_train_time(end_time, start_time)
             return [
@@ -138,6 +139,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
             ]
 
         def _starting_message(func_name, host_name, notification, start_time):
+            """Uses Slack blocks to create an initial report of training."""
             return [
                 {"type": "section", "text": {"type": "mrkdwn", "text": notification}},
                 {"type": "divider"},
@@ -157,6 +159,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
             ]
 
         def _successful_message(func_name, host_name, notification, start_time, value):
+            """Uses Slack blocks to report a successful training run with statistics."""
             end_time = datetime.datetime.now()
             training_time = _format_train_time(end_time, start_time)
             blocks = [
@@ -208,6 +211,7 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
             return blocks
 
         def _format_train_time(end_time, start_time):
+            """Returns a time delta in format HH:MM:SS"""
             elapsed_time = end_time - start_time
             hours, remainder = divmod(elapsed_time.seconds, 3600)
             minutes, seconds = divmod(remainder, 60)
@@ -221,3 +225,4 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
         return wrapper_sender
 
     return decorator_sender
+

--- a/knockknock/slack_sender.py
+++ b/knockknock/slack_sender.py
@@ -93,10 +93,6 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                     minutes, seconds = divmod(remainder, 60)
                     training_time = "{:2d}:{:02d}:{:02d}".format(hours, minutes, seconds)
 
-                    contents = [,
-                                'End date: %s' % end_time.strftime(DATE_FORMAT),
-                                'Training duration: %s' % str(elapsed_time)]
-
                     dump['blocks'] = [{"type": "section",
                                        "text": {"type": "mrkdwn", "text": notification}},
                                       {"type": "divider"},
@@ -117,11 +113,12 @@ def slack_sender(webhook_url: str, channel: str, user_mentions: List[str] = []):
                                       }]
 
                     if value is not None:
+                        dump["blocks"].append({"type": "divider"})
                         try:
                             str_value = str(value)
                             dump["blocks"].append({"type": "section",
                                                    "text": {"type": "mrkdwn",
-                                                            "text": 'Main call returned value: {}'.format(str_value)}})
+                                                            "text": '*Main call returned value:* {}'.format(str_value)}})
                         except Exception as e:
                             dump["blocks"].append("Couldn't str the returned value due to the following error: \n`{}`".format(e))
 


### PR DESCRIPTION
Happy holidays! 🎅🏼
I thought the slack message formatting looked a little sad, so I updated it.  I used the [block kit builder](https://api.slack.com/tools/block-kit-builder) to update the messages.

I also updated the `slack_sender` to use usernames instead of `user_id`s (perhaps I used this incorrectly, but posting the `user_id` never tagged the right person)

 The reports look like this now:

<img width="647" alt="Screenshot 2019-12-26 at 7 11 25 pm" src="https://user-images.githubusercontent.com/35203669/71487627-68be9980-2814-11ea-97ad-ce4a3a69d2b4.png">
