### PR TITLE
Added Linux option for Desktop notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ knockknock discord \
 ### Desktop Notification
 
 You can also get notified from a desktop notification. It is currently only available for MacOS and Linux.
+For Linux it uses the nofity-send command which uses libnotify, In order to use libnotify, you have to install a notification server. Cinnamon, Deepin, Enlightenment, GNOME, GNOME Flashback and KDE Plasma use their own implementations to display notifications. In other desktop environments, the notification server needs to be launched using your WM's/DE's "autostart" option. 
 
 #### Python
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ knockknock discord \
 
 ### Desktop Notification
 
-You can also get notified from a desktop notification. It is currently only available for MacOS.
+You can also get notified from a desktop notification. It is currently only available for MacOS and Linux.
 
 #### Python
 

--- a/knockknock/desktop_sender.py
+++ b/knockknock/desktop_sender.py
@@ -4,12 +4,17 @@ import traceback
 import functools
 import socket
 import subprocess
+import platform
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 def desktop_sender(title:str="knockknock"):
     
     def show_notification(text:str,title:str):
-        subprocess.run(["sh", "-c", "osascript -e 'display notification \"%s\" with title \"%s\"'" % (text, title)])
+        if platform.system() == "Darwin":     
+            subprocess.run(["sh", "-c", "osascript -e 'display notification \"%s\" with title \"%s\"'" % (text, title)])
+        
+        elif platform.system() == "Linux":
+            subprocess.run(["notify-send", title, text])        
 
     def decorator_sender(func):
         @functools.wraps(func)

--- a/knockknock/desktop_sender.py
+++ b/knockknock/desktop_sender.py
@@ -10,6 +10,7 @@ DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 def desktop_sender(title:str="knockknock"):
     
     def show_notification(text:str,title:str):
+        # Check the OS
         if platform.system() == "Darwin":     
             subprocess.run(["sh", "-c", "osascript -e 'display notification \"%s\" with title \"%s\"'" % (text, title)])
         

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from io import open
 
 setup(
     name='knockknock',
-    version='0.1.7',
+    version='0.1.8',
     description='Be notified when your training is complete with only two additional lines of code',
     long_description=open('README.md', 'r', encoding='utf-8').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I added an option to send Desktop notifications on Linux machines
I'm currently running an Ubuntu 19.10 machine which I tested on and it works.
it uses the notify-send Linux command. added some explanation in the readme for people on how to make sure the notification appears.