### PR TITLE
Added telegram_print function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ def train_your_nicest_model(your_nicest_parameters):
     import time
     time.sleep(10000)
     return {'loss': 0.9} # Optional return value
+
+#For sending direct message to telegram(Optional)
+from knockknock import telegram_print
+
+telegram_print(text="<your_text>",token=token="<your_api_token>", chat_id=CHAT_ID)
 ```
 
 #### Command-line

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ def train_your_nicest_model(your_nicest_parameters):
 #For sending direct message to telegram(Optional)
 from knockknock import telegram_print
 
-telegram_print(text="<your_text>",token=token="<your_api_token>", chat_id=CHAT_ID)
+telegram_print(text="<your_text>",token="<your_api_token>", chat_id=CHAT_ID)
 ```
 
 #### Command-line

--- a/knockknock/telegram_sender.py
+++ b/knockknock/telegram_sender.py
@@ -95,3 +95,10 @@ def telegram_sender(token: str, chat_id: int):
         return wrapper_sender
 
     return decorator_sender
+
+
+def telegram_print(text:str,token: str, chat_id: int):
+    # telegram print sends the message to the telegram 
+    # Ex: It can be used to send loss,accuracy during each epoch
+     bot = telegram.Bot(token=token)
+     bot.send_message(chat_id=chat_id, text=text)


### PR DESCRIPTION
Thanks for this wonderful library.

When I commit a kernel in Kaggle I use knockkncok(telegram_sender) so that I 'll get to know the status of training. But the problem is I am unable to view some important data such as loss or accuracy for each epoch while the model is training.

So, I thought of writing a simple function

> telegram_print(text="<your_text>",token="<your_api_token>", chat_id=CHAT_ID)

which can be used to send the message directly to telegram while training. It helps a lot to kill the kernel when the model is not performing well and thereby saving GPU.