### PR TITLE
Fix raise import error in desktop

### DIFF
--- a/knockknock/desktop_sender.py
+++ b/knockknock/desktop_sender.py
@@ -22,7 +22,7 @@ def desktop_sender(title: str = "knockknock"):
             try:
                 from win10toast import ToastNotifier
             except ImportError as err:
-                print('Error: to use Windows Desktop Notifications, you need to install `win10toast` first. Please run `pip install win10toast==0.9`.')
+                raise ImportError('Error: to use Windows Desktop Notifications, you need to install `win10toast` first. Please run `pip install win10toast==0.9`.')
 
             toaster = ToastNotifier()
             toaster.show_toast(title,


### PR DESCRIPTION
Currently, knockknock will only print the error message instead of raise an error when `win10toast` is not install on win10 desktop. This PR fixes it so that user will correctly see
```bash
ImportError: Error: to use Windows Desktop Notifications, you need to install `win10toast` first. Please run `pip install win10toast==0.9`.
```

instead of
```bash
UnboundLocalError: local variable 'ToastNotifier' referenced before assignment
```