### PR TITLE
New Feature: Add a config enable general decorator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ MANIFEST
 
 # Ignore Mac DS_Store files
 .DS_Store
+*.ini

--- a/knockknock/__init__.py
+++ b/knockknock/__init__.py
@@ -10,3 +10,6 @@ from knockknock.matrix_sender import matrix_sender
 from knockknock.dingtalk_sender import dingtalk_sender
 from knockknock.wechat_sender import wechat_sender
 from knockknock.rocketchat_sender import rocketchat_sender
+
+# general decorator
+from knockknock.knockknock import knockknock

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -40,40 +40,40 @@ def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
         A config file with sender keys in `SENDER_DICT` as its section name and set the sender
         parameters as passed values.
     """
-    config_file = os.path.join(config_path, config_name)
-    if not os.path.isfile(config_file):
-        warnings.warn(
-            f'The config file {config_file} is not existed. Knockknock would not send message.'
-        )
-
-    # read the config file
-    sender_config = configparser.ConfigParser()
-    sender_config.read(config_file)
-
-    # here we only select the `knockknock` section inside the config file as valid sender setting
-    sender_class = None
-    sender_param = {}
     do_notification = False
-    if 'knockknock' in sender_config:
-        sender_section = dict(sender_config['knockknock'])
+    config_file = os.path.join(config_path, config_name)
+    if os.path.isfile(config_file):
+        # read the config file
+        sender_config = configparser.ConfigParser()
+        sender_config.read(config_file)
 
-        # get sender class
-        sender_class_name = sender_section.pop('sender', None)
-        if sender_class_name not in SENDER_DICT:
-            raise ValueError(
-                f'The sender type {sender_class_name} defined in the config file is invalid in'
-                + f' ({" ".join(SENDER_DICT.keys())}).'
+        # here we only select the `knockknock` section inside the config file as valid sender setting
+        sender_class = None
+        sender_param = {}
+        if 'knockknock' in sender_config:
+            sender_section = dict(sender_config['knockknock'])
+
+            # get sender class
+            sender_class_name = sender_section.pop('sender', None)
+            if sender_class_name not in SENDER_DICT:
+                raise ValueError(
+                    f'The sender type {sender_class_name} defined in the config file is invalid in'
+                    + f' ({" ".join(SENDER_DICT.keys())}).'
+                )
+
+            # set notification parameters
+            do_notification = sender_section.pop('notification', True)
+            sender_class = SENDER_DICT[sender_class_name]
+
+            # special keys pop out in above
+            sender_param = sender_section
+        else:
+            warnings.warn(
+                f'The config file {config_file} is empty. Knockknock would not send message.'
             )
-
-        # set notification parameters
-        do_notification = sender_section.pop('notification', True)
-        sender_class = SENDER_DICT[sender_class_name]
-
-        # special keys pop out in above
-        sender_param = sender_section
     else:
         warnings.warn(
-            f'The config file {config_file} is empty. Knockknock would not send message.'
+            f'The config file {config_file} is not existed. Knockknock would not send message.'
         )
 
     def wrap_knock(func):

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -1,0 +1,93 @@
+import os
+import configparser
+import warnings
+
+from knockknock.chime_sender import chime_sender
+from knockknock.discord_sender import discord_sender
+from knockknock.email_sender import email_sender
+from knockknock.slack_sender import slack_sender
+from knockknock.sms_sender import sms_sender
+from knockknock.telegram_sender import telegram_sender
+from knockknock.teams_sender import teams_sender
+from knockknock.desktop_sender import desktop_sender
+from knockknock.matrix_sender import matrix_sender
+from knockknock.dingtalk_sender import dingtalk_sender
+from knockknock.wechat_sender import wechat_sender
+from knockknock.rocketchat_sender import rocketchat_sender
+
+
+SENDER_DICT = {
+    'chime': chime_sender,
+    'discord': discord_sender,
+    'email': email_sender,
+    'slack': slack_sender,
+    'sms': sms_sender,
+    'telegram': telegram_sender,
+    'teams': teams_sender,
+    'desktop': desktop_sender,
+    'matrix': matrix_sender,
+    'dingtalk': dingtalk_sender,
+    'wechat': wechat_sender,
+    'rocketchat': rocketchat_sender
+}
+
+
+def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
+    """
+    A general decorator reading the config file and wrapping the function to according sender.
+
+    `config_file`: str
+        A config file with sender keys in `SENDER_DICT` as its section name and set the sender
+        parameters as passed values.
+    """
+    config_file = os.path.join(config_path, config_name)
+    if not os.path.isfile(config_file):
+        raise Exception(f'{config_file} is not a valid config file path')
+
+    # read the config file
+    sender_config = configparser.ConfigParser()
+    sender_config.read(config_file)
+
+    # here we only select the `knockknock` section inside the config file as valid sender setting
+    sender_class = None
+    sender_param = {}
+    do_notification = False
+    if 'knockknock' in sender_config:
+        sender_section = dict(sender_config['knockknock'])
+
+        # get sender class
+        sender_class_name = sender_section.pop('sender', None)
+        if sender_class_name not in SENDER_DICT:
+            raise ValueError(
+                f'The sender type {sender_class_name} defined in the config file is invalid in'
+                + f' ({" ".join(SENDER_DICT.keys())}).'
+            )
+
+        # set notification parameters
+        do_notification = sender_section.pop('notification', True)
+        sender_class = SENDER_DICT[sender_class_name]
+
+        # special keys pop out in above
+        sender_param = sender_section
+    else:
+        warnings.warn(
+            f'The config file {config_file} is empty. Knockknock would not send message.'
+        )
+
+    def wrap_knock(func):
+        if do_notification:
+            sender_decorator = sender_class(**sender_param)
+            return sender_decorator(func)
+        else:
+            return func
+    return wrap_knock
+
+
+if __name__ == '__main__':
+    @knockknock(config_name='test.ini')
+    def train_your_model(your_nicest_parameters):
+        import time
+        time.sleep(10)
+        return {'loss': 0.9}  # Optional return value
+
+    train_your_model(None)

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -84,13 +84,3 @@ def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
         else:
             return func
     return wrap_knock
-
-
-if __name__ == '__main__':
-    @knockknock(config_name='test.ini')
-    def train_your_model(your_nicest_parameters):
-        import time
-        time.sleep(10)
-        return {'loss': 0.9}  # Optional return value
-
-    train_your_model(None)

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -36,7 +36,10 @@ def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
     """
     A general decorator reading the config file and wrapping the function to according sender.
 
-    `config_file`: str
+    `config_path`: str
+        A config folder contains your knockknock config file.
+
+    `config_name`: str
         A config file with sender keys in `SENDER_DICT` as its section name and set the sender
         parameters as passed values.
     """

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -42,7 +42,9 @@ def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
     """
     config_file = os.path.join(config_path, config_name)
     if not os.path.isfile(config_file):
-        raise Exception(f'{config_file} is not a valid config file path')
+        warnings.warn(
+            f'The config file {config_file} is not existed. Knockknock would not send message.'
+        )
 
     # read the config file
     sender_config = configparser.ConfigParser()

--- a/knockknock/knockknock.py
+++ b/knockknock/knockknock.py
@@ -57,12 +57,13 @@ def knockknock(config_path: str = "./", config_name: str = "knockknock.ini"):
             sender_class_name = sender_section.pop('sender', None)
             if sender_class_name not in SENDER_DICT:
                 raise ValueError(
-                    f'The sender type {sender_class_name} defined in the config file is invalid in'
-                    + f' ({" ".join(SENDER_DICT.keys())}).'
+                    f'The sender type `{sender_class_name}` defined in the config file'
+                    + f' {config_file} is invalid.'
+                    + f' Support sender types: {", ".join(SENDER_DICT.keys())}.'
                 )
 
             # set notification parameters
-            do_notification = sender_section.pop('notification', True)
+            do_notification = eval(sender_section.pop('notification', 'True'))
             sender_class = SENDER_DICT[sender_class_name]
 
             # special keys pop out in above


### PR DESCRIPTION
Hey all,

I just used knockknock frequently in my previous research experiment. And I found it is inconvenient at this time if I want to use knockknock multiple times in my codebase. Because I need to maintain consistent sender function parameters in my code everywhere. And it is easy to leakage my personal security token (such as slack webhook_url). As a result, I propose to add a general decorator to handle these tricky things. 

**Property:**

1. This general decorator can parse a config file to handle different sender function parameters.
2. The decorator can be silent when we are debugging our codebase. Since at the debug stage, we don't need verbose notification.
3. Separate the sender config in an independent config file can mitigate the risk of information leakage. (Just adding the config file into your `.gitignore` file.)


I finished the above properties. And I tested it on my personal desktop (Mac).

**Below are some code examples:**
- Usage of general decorator
```python
from knockknock import knockknock  # general decorator is named as knockknock (like tqdm)

@knockknock(config_path='./', config_name='test.ini')  # directly set your config path
def train_your_model(your_nicest_parameters):
    import time
    time.sleep(10)
    return {'loss': 0.9}  # Optional return value


@knockknock(config_path='./', config_name='test.ini')  # convenient to use it multiple times in your codebase
def eval_your_model(your_nicest_parameters):
    import time
    time.sleep(10)
    return {'acc': 0.9}  # Optional return value


train_your_model(None)
eval_your_model(None)
```

- Config file `test.ini`
```
[knockknock]
sender=your_sender_type
notification=True
webhook_url=your_webhook_url
channel=your_channel
```
If `notification` is not set, it will be `True` by default.  The config file must be started with the `knockknock` tag. And the `sender` determines the sender type. Other parameters are related to according sender function.