### PR TITLE
Update: email_sender description. See Issue #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are currently *twelve* ways to setup notifications:
 
 ### Email
 
-The service relies on [Yagmail](https://github.com/kootenpv/yagmail) a GMAIL/SMTP client. You'll need a gmail email address to use it (you can setup one [here](https://accounts.google.com), it's free). I recommend creating a new one (rather than your usual one) since you'll have to modify the account's security settings to allow the Python library to access it by [Turning on less secure apps](https://devanswers.co/allow-less-secure-apps-access-gmail-account/).
+The service relies on [Yagmail](https://github.com/kootenpv/yagmail) a GMAIL/SMTP client. You'll need a gmail email address to use it (you can setup one [here](https://accounts.google.com), it's free). I recommend creating a new one (rather than your usual one) since you'll have to modify the account's security settings to allow the Python library to access it by [creating and signing in with an App Password](https://support.google.com/mail/answer/185833?hl).
 
 #### Python
 


### PR DESCRIPTION
Google does no longer support login from "less secure apps". Users must now create an app password for knockknock's email sender to work.